### PR TITLE
Minor fixes to README for OSX

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,23 @@ Install pip
 
     sudo easy_install pip
 
+Known Errors
+^^^^^^^^^^^^
+
+::
+
+    ValueError: No backend available
+
+This means that the Python usb module cannot find your installation of libusb.
+It seems to be an issue when you have ``homebrew`` installed somewhere that is
+not expected.
+
+It can be mitigated with
+
+::
+
+    sudo ln -s `brew --prefix`/lib/libusb-* /usr/local/lib/
+
 Microsoft Windows
 `````````````````
 


### PR DESCRIPTION
Issues fixed:
- Homebrew does not require (and advises against) sudo (removed from README.rst)
- If you have Homebrew in a non-standard place, libusb can't be found (workaround documented)
