### PR TITLE
Compare strings with `==` not `is`

### DIFF
--- a/blinkstick/blinkstick.py
+++ b/blinkstick/blinkstick.py
@@ -350,7 +350,7 @@ class BlinkStick(object):
         try:
             if name:
                 # Special case for name="random"
-                if name is "random":
+                if name == "random":
                     red = randint(0, 255)
                     green = randint(0, 255)
                     blue = randint(0, 255)


### PR DESCRIPTION
For instance:

    >>> r = ''.join(['r','a','n','d','o','m'])
    >>> r == 'random'
    True
    >>> r is 'random'
    False
    >>> intern(r) is 'random'
    True

Meanwhile, the workaround is to call `intern` on the given string.
For instance:

    >>> led.pulse(name=intern(r))