### PR TITLE
Add trailing newline to udev rule

### DIFF
--- a/bin/blinkstick
+++ b/bin/blinkstick
@@ -276,7 +276,7 @@ def main():
         try:
             filename = "/etc/udev/rules.d/85-blinkstick.rules"
             file = open(filename, 'w')
-            file.write('SUBSYSTEM=="usb", ATTR{idVendor}=="20a0", ATTR{idProduct}=="41e5", MODE:="0666"')
+            file.write('SUBSYSTEM=="usb", ATTR{idVendor}=="20a0", ATTR{idProduct}=="41e5", MODE:="0666"\n')
             file.close()
 
             print "Rule added to " + filename


### PR DESCRIPTION
I noticed when running `udevadm` that the rule installed by `blinkstick` was syntactically invalid:

    invalid key/value pair in file /etc/udev/rules.d/85-blinkstick.rules on line 1,starting at character 80 ('')

Add a newline to the written file to fix this.