### PR TITLE
A typo on line 230

### DIFF
--- a/bin/blinkstick
+++ b/bin/blinkstick
@@ -227,7 +227,7 @@ def main():
             file.write('SUBSYSTEM=="usb", ATTR{idVendor}=="20a0", ATTR{idProduct}=="41e5", MODE:="0666"')
             file.close()
 
-            print("Rule added to {0}").format(filename)
+            print("Rule added to {0}".format(filename))
         except IOError as e:
             print(str(e))
             print("Make sure you run this script as root: sudo blinkstick --add-udev-rule")


### PR DESCRIPTION
A typo on line 230 gives an error, when creating a udev rule.