### PR TITLE
Fix issue #57 : check for device while get serial

### DIFF
--- a/blinkstick/blinkstick.py
+++ b/blinkstick/blinkstick.py
@@ -246,6 +246,8 @@ class BlinkStick(object):
                     raise BlinkStickException("Could not communicate with BlinkStick {0} - it may have been removed".format(self.bs_serial))
 
     def _refresh_device(self):
+        if not hasattr(self, serial):
+            return False
         d = find_by_serial(self.bs_serial)
         if d:
             self.device = d.device


### PR DESCRIPTION
Once USB connection is lost, the init get no device and then the
bs_serial variable is not set