### PR TITLE
Make _usb_ctrl_transfer Python 3 compatible

### DIFF
--- a/blinkstick/blinkstick.py
+++ b/blinkstick/blinkstick.py
@@ -231,7 +231,10 @@ class BlinkStick(object):
     def _usb_ctrl_transfer(self, bmRequestType, bRequest, wValue, wIndex, data_or_wLength):
         if sys.platform == "win32":
             if bmRequestType == 0x20:
-                data = (c_ubyte * len(data_or_wLength))(*[c_ubyte(ord(c)) for c in data_or_wLength])
+                if sys.version_info[0] < 3:
+                    data = (c_ubyte * len(data_or_wLength))(*[c_ubyte(ord(c)) for c in data_or_wLength])
+                else:
+                    data = (c_ubyte * len(data_or_wLength))(*[c_ubyte(c) for c in data_or_wLength])
                 data[0] = wValue
                 if not self.device.send_feature_report(data):
                     if self._refresh_device():


### PR DESCRIPTION
The `data_or_wLength` argument is of type `'str'` in Pyhton 2, whereas it's `'bytes'` in Python 3. Calling `ord()` to convert the character to binary unicode representation is therefore no longer needed on Python 3.

This fixes issue #34 on Python 3 while retaining Python 2 compatibility. Tested locally on Python 2.7 (32bit) and Python 3.7 (64bit).