### PR TITLE
Make sure to use python3

### DIFF
--- a/bin/blinkstick
+++ b/bin/blinkstick
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from optparse import OptionParser, IndentedHelpFormatter, OptionGroup
 from blinkstick import blinkstick


### PR DESCRIPTION
`python` on most systems refers to Python 2, and on Python 3 only systems there doesn't exist a `python` at all in some cases (e.g. Alpine Linux). Instead make sure to _always_ use Python 3 and be explicit about the version we require.