### PR TITLE
Changed dependency on pyusb to accept anything higher than 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.platform == "win32":
     ]
 else:
     os_requires = [
-        "pyusb==1.0.0"
+        "pyusb>=1.0.0"
     ]
 
 setup(


### PR DESCRIPTION
It can't be expected that everybody will use 1.0.0 only, e.g.
distribution packaging. I've already confirmed it works fine with pyusb
1.2.0 as well, so let's just accept anything higher than 1.0.0