### PR TITLE
Fix print statement in setup.py for 'unable to find version' message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ nosetests.xml
 
 #idea pycharm
 .idea
+venv

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ else:
     if mo:
         verstr = mo.group(1)
     else:
-        print("unable to find version in {0}").format(VERSIONFILE)
+        print("unable to find version in {0}".format(VERSIONFILE))
         raise RuntimeError("if {0}.py exists, it is required to be well-formed".format(VERSIONFILE))
 
 if sys.platform == "win32":


### PR DESCRIPTION
`format()` is mistakenly called on return value of `print()` instead of on the format string.

Fixes the typeo so the intended error message will be printed and intended exception thrown.