### PR TITLE
Fix blinkstick CLI to suppress help message when setting info block.

### DIFF
--- a/bin/blinkstick
+++ b/bin/blinkstick
@@ -318,6 +318,8 @@ def main():
 
             func(**fargs)
 
+        elif options.infoblock1 or options.infoblock2:
+            pass
 
         else:
             parser.print_help()


### PR DESCRIPTION
Currently, the blinkstick CLI prints the help message when the info-block 1 and/or 2 are set. This fix suppresses the help message when setting the info-block(s).