### PR TITLE
refactor: Reconfigure package imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dev = ["black", "isort"]
 test = ["coverage", "pytest", "pytest-cov", "pytest-mock"]
 
 [project.scripts]
-blinkstick = "blinkstick:main"
+blinkstick = "blinkstick.main:main"
 
 [project.urls]
 homepage = "https://pypi.python.org/pypi/blinkstick/"

--- a/src/blinkstick/__init__.py
+++ b/src/blinkstick/__init__.py
@@ -1,5 +1,10 @@
-from .main import main
 from importlib.metadata import version, PackageNotFoundError
+
+from .blinkstick import BlinkStick, BlinkStickPro, BlinkStickProMatrix
+from .blinkstick import find_all, find_by_serial, find_first, get_blinkstick_package_version
+from .colors import Color, ColorFormat
+from .constants import BlinkStickVariant
+from .exceptions import BlinkStickException
 
 try:
     __version__ = version("blinkstick")

--- a/src/blinkstick/main.py
+++ b/src/blinkstick/main.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 from optparse import OptionParser, IndentedHelpFormatter, OptionGroup
-from blinkstick import blinkstick
-from blinkstick.constants import BlinkStickVariant
 import textwrap
 import sys
 import logging
+
+from .blinkstick import get_blinkstick_package_version, find_all, find_by_serial
+from .constants import BlinkStickVariant
 logging.basicConfig()
 
 
@@ -71,7 +72,7 @@ class IndentedHelpFormatterWithNL(IndentedHelpFormatter):
 
     def format_usage(self, usage):
         return "BlinkStick control script %s\n(c) Agile Innovative Ltd 2013-2014\n\n%s" % (
-        blinkstick.get_blinkstick_package_version(), IndentedHelpFormatter.format_usage(self, usage))
+        get_blinkstick_package_version(), IndentedHelpFormatter.format_usage(self, usage))
 
 
 def print_info(stick):
@@ -217,9 +218,9 @@ def main():
     (options, args) = parser.parse_args()
 
     if options.serial is None:
-        sticks = blinkstick.find_all()
+        sticks = find_all()
     else:
-        sticks = [blinkstick.find_by_serial(options.serial)]
+        sticks = [find_by_serial(options.serial)]
 
         if len(sticks) == 0:
             print("BlinkStick with serial number " + options.backend + " not found...")


### PR DESCRIPTION
This pull request includes changes to the `src/blinkstick/__init__.py` file to improve module imports and organization. The most important changes include adding imports for key classes and functions, and removing an unnecessary import.

Improvements to module imports:

* Added imports for `BlinkStick`, `BlinkStickPro`, `BlinkStickProMatrix`, `find_all`, `find_by_serial`, and `find_first` from the `blinkstick` module.
* Added imports for `Color` and `ColorFormat` from the `colors` module.
* Added import for `BlinkStickVariant` from the `constants` module.
* Added import for `BlinkStickException` from the `exceptions` module.

Codebase simplification:

* Removed the import for `main` from the `main` module.Improve the discoverability of the key parts of the blinkstick package by exposing them at the top level.