### PR TITLE
pass correct data type to `remap_rgb_value` and `remap_rgb_value_reverse`

### DIFF
--- a/src/blinkstick/blinkstick.py
+++ b/src/blinkstick/blinkstick.py
@@ -184,7 +184,7 @@ class BlinkStick:
         except ValueError:
             red = green = blue = 0
 
-        red, green, blue = remap_rgb_value([red, green, blue], self.max_rgb_value)
+        red, green, blue = remap_rgb_value((red, green, blue), self.max_rgb_value)
 
         # TODO - do smarts to determine input type from red var in case it is not int
 
@@ -540,7 +540,7 @@ class BlinkStick:
 
         r_end, g_end, b_end = self._determine_rgb(red=red, green=green, blue=blue, name=name, hex=hex)
         # descale the above values
-        r_end, g_end, b_end = remap_rgb_value_reverse([r_end, g_end, b_end], self.max_rgb_value)
+        r_end, g_end, b_end = remap_rgb_value_reverse((r_end, g_end, b_end), self.max_rgb_value)
 
         r_start, g_start, b_start = remap_rgb_value_reverse(self._get_color_rgb(index), self.max_rgb_value)
 


### PR DESCRIPTION
This pull request includes changes to the `src/blinkstick/blinkstick.py` file to improve the handling of RGB values. The most important changes involve modifying the data structures used in the `remap_rgb_value` and `remap_rgb_value_reverse` functions.

Improvements to RGB value handling:

* [`src/blinkstick/blinkstick.py`](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL187-R187): Changed the input parameter from a list to a tuple in the `_determine_rgb` method to improve the handling of RGB values.
* [`src/blinkstick/blinkstick.py`](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL543-R543): Changed the input parameter from a list to a tuple in the `morph` method to ensure consistency and proper handling of RGB values.