### PR TITLE
Return correct data type from `_get_color` and `_get_color_rgb`

### DIFF
--- a/src/blinkstick/blinkstick.py
+++ b/src/blinkstick/blinkstick.py
@@ -200,7 +200,7 @@ class BlinkStick:
         else:
             data = self.get_led_data((index + 1) * 3)
 
-            return [data[index * 3 + 1], data[index * 3], data[index * 3 + 2]]
+            return data[index * 3 + 1], data[index * 3], data[index * 3 + 2]
 
     def _get_color_hex(self, index=0):
         r, g, b = self._get_color_rgb(index)
@@ -722,7 +722,7 @@ class BlinkStickPro:
         """
 
         val = self.data[channel][index]
-        return [val[1], val[0], val[2]]
+        return val[1], val[0], val[2]
 
     def clear(self):
         """
@@ -897,7 +897,7 @@ class BlinkStickProMatrix(BlinkStickPro):
         """
 
         val = self.matrix_data[self._coord_to_index(x, y)]
-        return [val[1], val[0], val[2]]
+        return val[1], val[0], val[2]
 
     def shift_left(self, remove=False):
         """


### PR DESCRIPTION
This pull request includes changes to the `src/blinkstick/blinkstick.py` file to improve the return type consistency of color-related methods. The changes involve modifying methods to return tuples instead of lists.

Changes to return type consistency:

* [`src/blinkstick/blinkstick.py`](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL203-R203): Modified the `_get_color_rgb` method to return a tuple instead of a list.
* [`src/blinkstick/blinkstick.py`](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL725-R725): Modified the `get_color` method for channel and index to return a tuple instead of a list.
* [`src/blinkstick/blinkstick.py`](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL900-R900): Modified the `get_color` method for coordinates to return a tuple instead of a list.