### PR TITLE
Add type hinting throughout project

### DIFF
--- a/src/blinkstick/backends/base.py
+++ b/src/blinkstick/backends/base.py
@@ -29,17 +29,17 @@ class BaseBackend(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_serial(self):
+    def get_serial(self) -> str:
         raise NotImplementedError
 
     @abstractmethod
-    def get_manufacturer(self):
+    def get_manufacturer(self) -> str:
         raise NotImplementedError
 
     @abstractmethod
-    def get_version_attribute(self):
+    def get_version_attribute(self) -> int:
         raise NotImplementedError
 
     @abstractmethod
-    def get_description(self):
+    def get_description(self) -> str:
         raise NotImplementedError

--- a/src/blinkstick/backends/unix_like.py
+++ b/src/blinkstick/backends/unix_like.py
@@ -10,6 +10,8 @@ from blinkstick.exceptions import BlinkStickException
 
 class UnixLikeBackend(BaseBackend):
 
+    serial: str
+
     def __init__(self, device=None):
         self.device = device
         super().__init__()
@@ -17,7 +19,7 @@ class UnixLikeBackend(BaseBackend):
             self.open_device()
             self.serial = self.get_serial()
 
-    def open_device(self):
+    def open_device(self) -> None:
         if self.device is None:
             raise BlinkStickException("Could not find BlinkStick...")
 
@@ -26,8 +28,6 @@ class UnixLikeBackend(BaseBackend):
                 self.device.detach_kernel_driver(0)
             except usb.core.USBError as e:
                 raise BlinkStickException("Could not detach kernel driver: %s" % str(e))
-
-        return True
 
     def _refresh_device(self):
         if not self.serial:
@@ -67,23 +67,23 @@ class UnixLikeBackend(BaseBackend):
     def get_serial(self) -> str:
         return self._usb_get_string(3)
 
-    def get_manufacturer(self):
+    def get_manufacturer(self)-> str:
         return self._usb_get_string(1)
 
-    def get_version_attribute(self):
-        return self.device.bcdDevice
+    def get_version_attribute(self) -> int:
+        return int(self.device.bcdDevice)
 
     def get_description(self):
         return self._usb_get_string(2)
 
-    def _usb_get_string(self, index):
+    def _usb_get_string(self, index: int) -> str:
         try:
-            return usb.util.get_string(self.device, index, 1033)
+            return str(usb.util.get_string(self.device, index, 1033))
         except usb.USBError:
             # Could not communicate with BlinkStick backend
             # attempt to find it again based on serial
 
             if self._refresh_device():
-                return usb.util.get_string(self.device, index, 1033)
+                return str(usb.util.get_string(self.device, index, 1033))
             else:
                 raise BlinkStickException("Could not communicate with BlinkStick {0} - it may have been removed".format(self.serial))

--- a/src/blinkstick/backends/win32.py
+++ b/src/blinkstick/backends/win32.py
@@ -65,14 +65,14 @@ class Win32Backend(BaseBackend):
         elif bmRequestType == 0x80 | 0x20:
             return self.reports[wValue - 1].get()
 
-    def get_serial(self):
-        return self.device.serial_number
+    def get_serial(self) -> str:
+        return str(self.device.serial_number)
 
-    def get_manufacturer(self):
-        return self.device.vendor_name
+    def get_manufacturer(self) -> str:
+        return str(self.device.vendor_name)
 
-    def get_version_attribute(self):
-        return self.device.version_number
+    def get_version_attribute(self) -> int:
+        return int(self.device.version_number)
 
-    def get_description(self):
-        return self.device.product_name
+    def get_description(self) -> str:
+        return str(self.device.product_name)

--- a/src/blinkstick/constants.py
+++ b/src/blinkstick/constants.py
@@ -15,11 +15,11 @@ class BlinkStickVariant(Enum):
     BLINKSTICK_FLEX = (6, "BlinkStick Flex")
 
     @property
-    def value(self):
+    def value(self) -> int:
         return self._value_[0]
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self._value_[1]
 
     @staticmethod


### PR DESCRIPTION
This pull request primarily focuses on adding type annotations to various methods across multiple files to improve code clarity and type safety. The changes span several classes and methods, ensuring that return types and parameter types are explicitly defined.

### Type Annotations:

* [`src/blinkstick/backends/base.py`](diffhunk://#diff-9604602ab17f6e3fd7497820eef724de6af35501f85580969f28512a5db689a8L32-R44): Added type annotations to methods in the `BaseBackend` class, specifying return types for methods like `get_serial`, `get_manufacturer`, `get_version_attribute`, and `get_description`.

* [`src/blinkstick/backends/unix_like.py`](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326R13-R22): Introduced type annotations for methods in the `UnixLikeBackend` class, including `open_device`, `get_manufacturer`, `get_version_attribute`, and `_usb_get_string`. Removed an unnecessary return statement in `open_device`. [[1]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326R13-R22) [[2]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L30-L31) [[3]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L70-R87)

* [`src/blinkstick/backends/win32.py`](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67L68-R78): Updated methods in the `Win32Backend` class to include type annotations for methods such as `get_serial`, `get_manufacturer`, `get_version_attribute`, and `get_description`.

* [`src/blinkstick/blinkstick.py`](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bR1-R2): Added type annotations to numerous methods in the `BlinkStick` and `BlinkStickPro` classes, covering methods like `get_serial`, `set_color`, `get_color`, `set_mode`, `get_mode`, and more. Also included type annotations for class attributes and parameters in constructors. [[1]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bR1-R2) [[2]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL47-R52) [[3]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL63-R68) [[4]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL80-R85) [[5]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL113-R118) [[6]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL122-R127) [[7]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL131-R136) [[8]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL171-R176) [[9]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL193-R198) [[10]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL205-R214) [[11]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL252-R257) [[12]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL271-R276) [[13]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL293-R298) [[14]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL309-R314) [[15]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL328-R333) [[16]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL351-R356) [[17]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL378-R383) [[18]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL398-R403) [[19]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL415-R420) [[20]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL434-R439) [[21]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL445-R450) [[22]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL456-R473) [[23]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL494-R499) [[24]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL521-R526) [[25]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL648-R663) [[26]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL690-R705) [[27]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL711-R726)

These changes enhance the readability and maintainability of the code by making the expected types of method parameters and return values explicit.