### PR TITLE
chore: Refactor type hinting in BaseBackend and its subclasses

### DIFF
--- a/src/blinkstick/backends/base.py
+++ b/src/blinkstick/backends/base.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from typing import TypeVar, Generic
 
-class BaseBackend(ABC):
+T = TypeVar("T")
+
+
+class BaseBackend(ABC, Generic[T]):
 
     serial: str | None
 
@@ -16,12 +20,12 @@ class BaseBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def find_blinksticks(find_all: bool = True):
+    def find_blinksticks(find_all: bool = True) -> list[T] | None:
         raise NotImplementedError
 
     @staticmethod
     @abstractmethod
-    def find_by_serial(serial: str) -> BaseBackend | None:
+    def find_by_serial(serial: str) -> list[T] | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/blinkstick/backends/unix_like.py
+++ b/src/blinkstick/backends/unix_like.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-import usb.core
-import usb.util
+import usb.core  # type: ignore
+import usb.util  # type: ignore
 
 from blinkstick.constants import VENDOR_ID, PRODUCT_ID
 from blinkstick.backends.base import BaseBackend
 from blinkstick.exceptions import BlinkStickException
 
 
-class UnixLikeBackend(BaseBackend):
+class UnixLikeBackend(BaseBackend[usb.core.Device]):
 
     serial: str
+    device: usb.core.Device
 
     def __init__(self, device=None):
         self.device = device
@@ -38,13 +39,13 @@ class UnixLikeBackend(BaseBackend):
             return True
 
     @staticmethod
-    def find_blinksticks(find_all: bool = True):
+    def find_blinksticks(find_all: bool = True) -> list[usb.core.Device] | None:
         return usb.core.find(
             find_all=find_all, idVendor=VENDOR_ID, idProduct=PRODUCT_ID
         )
 
     @staticmethod
-    def find_by_serial(serial: str) -> list | None:
+    def find_by_serial(serial: str) -> list[usb.core.Device] | None:
         for d in UnixLikeBackend.find_blinksticks():
             try:
                 if usb.util.get_string(d, 3, 1033) == serial:
@@ -52,6 +53,8 @@ class UnixLikeBackend(BaseBackend):
                     return devices
             except Exception as e:
                 print("{0}".format(e))
+
+        return None
 
     def control_transfer(
         self,

--- a/src/blinkstick/blinkstick.py
+++ b/src/blinkstick/blinkstick.py
@@ -1412,8 +1412,10 @@ def find_all() -> list[BlinkStick]:
     @rtype: BlinkStick[]
     @return: a list of BlinkStick objects or None if no devices found
     """
-    result = []
-    for d in USBBackend.find_blinksticks():
+    result: list[BlinkStick] = []
+    if (found_devices := USBBackend.find_blinksticks()) is None:
+        return result
+    for d in found_devices:
         result.extend([BlinkStick(device=d)])
 
     return result


### PR DESCRIPTION
- Use `TypeVar` and `Generic` to define a generic type `T` in `BaseBackend`.
- Apply the generic type `T` to methods and attributes in `BaseBackend`.
- Update `Win32Backend` and `UnixLikeBackend` to specify the type for `T`.
- Reduce repetition of type hinting in constructors and method return types.

This pull request includes several changes to the `blinkstick` backends to improve type annotations and ensure type consistency across different backends. The most important changes include introducing generics to the `BaseBackend` class, updating method return types, and adding type ignores for certain imports.

Improvements to type annotations and consistency:

* [`src/blinkstick/backends/base.py`](diffhunk://#diff-9604602ab17f6e3fd7497820eef724de6af35501f85580969f28512a5db689a8R5-R10): Introduced generics to the `BaseBackend` class and updated method return types to use the new generic type `T`. [[1]](diffhunk://#diff-9604602ab17f6e3fd7497820eef724de6af35501f85580969f28512a5db689a8R5-R10) [[2]](diffhunk://#diff-9604602ab17f6e3fd7497820eef724de6af35501f85580969f28512a5db689a8L19-R28)
* [`src/blinkstick/backends/unix_like.py`](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L3-R14): Updated the `UnixLikeBackend` class to use the `usb.core.Device` type for the generic parameter `T` and updated method return types accordingly. [[1]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L3-R14) [[2]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L41-R48) [[3]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326R57-R58)
* [`src/blinkstick/backends/win32.py`](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67L6-R17): Updated the `Win32Backend` class to use the `hid.HidDevice` type for the generic parameter `T`, added type annotations for class attributes, and updated method return types accordingly. [[1]](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67L6-R17) [[2]](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67L23-R36) [[3]](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67L42-R48)
* `src/blinkstick/backends/unix_like.py` and `src/blinkstick/backends/win32.py`: Added `# type: ignore` comments to suppress type checking for `usb` and `pywinusb` imports. [[1]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L3-R14) [[2]](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67L6-R17)
* [`src/blinkstick/blinkstick.py`](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL1415-R1418): Improved the `find_all` method to handle cases where no devices are found by using a more concise and type-safe approach.