### PR TITLE
Add tests for string to bytes conversion and refactor

### DIFF
--- a/src/blinkstick/blinkstick.py
+++ b/src/blinkstick/blinkstick.py
@@ -16,6 +16,7 @@ from blinkstick.colors import (
 )
 from blinkstick.constants import VENDOR_ID, PRODUCT_ID, BlinkStickVariant
 from blinkstick.exceptions import BlinkStickException
+from blinkstick.utilities import string_to_info_block_data
 
 if sys.platform == "win32":
     from blinkstick.backends.win32 import Win32Backend as USBBackend
@@ -454,25 +455,6 @@ class BlinkStick:
             result += chr(i)
         return result
 
-    def _data_to_message(self, data: str) -> bytes:
-        """
-        Helper method to convert a string to byte array of 32 bytes.
-
-        @type  data: str
-        @param data: The data to convert to byte array
-
-        @rtype: byte[32]
-        @return: It fills the rest of bytes with zeros.
-        """
-        byte_array = bytearray([1])
-        for c in data:
-            byte_array.append(ord(c))
-
-        for i in range(32 - len(data)):
-            byte_array.append(0)
-
-        return bytes(byte_array)
-
     def set_info_block1(self, data: str) -> None:
         """
         Sets the infoblock1 with specified string.
@@ -482,7 +464,9 @@ class BlinkStick:
         @type  data: str
         @param data: InfoBlock1 for the backend to set
         """
-        self.backend.control_transfer(0x20, 0x9, 0x0002, 0, self._data_to_message(data))
+        self.backend.control_transfer(
+            0x20, 0x9, 0x0002, 0, string_to_info_block_data(data)
+        )
 
     def set_info_block2(self, data: str) -> None:
         """
@@ -493,7 +477,9 @@ class BlinkStick:
         @type  data: str
         @param data: InfoBlock2 for the backend to set
         """
-        self.backend.control_transfer(0x20, 0x9, 0x0003, 0, self._data_to_message(data))
+        self.backend.control_transfer(
+            0x20, 0x9, 0x0003, 0, string_to_info_block_data(data)
+        )
 
     def set_random_color(self) -> None:
         """

--- a/src/blinkstick/utilities.py
+++ b/src/blinkstick/utilities.py
@@ -1,0 +1,18 @@
+def string_to_info_block_data(data: str) -> bytes:
+    """
+    Helper method to convert a string to byte array of 32 bytes.
+
+    @type  data: str
+    @param data: The data to convert to byte array
+
+    @rtype: byte[32]
+    @return: It fills the rest of bytes with zeros.
+    """
+    byte_array = bytearray([1])
+    for c in data:
+        byte_array.append(ord(c))
+
+    for i in range(32 - len(data)):
+        byte_array.append(0)
+
+    return bytes(byte_array)

--- a/src/blinkstick/utilities.py
+++ b/src/blinkstick/utilities.py
@@ -8,11 +8,10 @@ def string_to_info_block_data(data: str) -> bytes:
     @rtype: byte[32]
     @return: It fills the rest of bytes with zeros.
     """
-    byte_array = bytearray([1])
-    for c in data:
-        byte_array.append(ord(c))
+    info_block_data = data[:31]
+    byte_array = bytearray([1] + [0] * 31)
 
-    for i in range(32 - len(data)):
-        byte_array.append(0)
+    for i, c in enumerate(info_block_data):
+        byte_array[i + 1] = ord(c)
 
     return bytes(byte_array)

--- a/tests/utilities/test_string_to_info_block.py
+++ b/tests/utilities/test_string_to_info_block.py
@@ -1,0 +1,29 @@
+from blinkstick.utilities import string_to_info_block_data
+
+
+def test_string_to_info_block_data_converts_string_to_byte_array():
+    block_string = "hello"
+    expected_padding_length = 31 - len(block_string)
+    result = string_to_info_block_data("hello")
+    expected = b"\x01hello" + b"\x00" * expected_padding_length
+    assert result == expected
+
+
+def test_string_to_info_block_data_handles_empty_string():
+    result = string_to_info_block_data("")
+    expected = b"\x01" + b"\x00" * 31
+    assert result == expected
+
+
+def test_string_to_info_block_data_truncates_long_string():
+    long_string = "a" * 40
+    result = string_to_info_block_data(long_string)
+    expected = b"\x01" + b"a" * 31
+    assert result == expected
+
+
+def test_string_to_info_block_data_handles_exact_31_characters():
+    exact_string = "a" * 31
+    result = string_to_info_block_data(exact_string)
+    expected = b"\x01" + b"a" * 31
+    assert result == expected


### PR DESCRIPTION
This pull request includes several changes to the `blinkstick` package, focusing on refactoring code and adding new utility functions and tests. The most important changes involve moving a helper method to a utility module and updating the code to use this new method.

Refactoring and code improvements:

* [`src/blinkstick/blinkstick.py`](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL457-L475): Removed the `_data_to_message` method and replaced its usage with the new `string_to_info_block_data` function. [[1]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL457-L475) [[2]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL485-R469) [[3]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL496-R482)
* [`src/blinkstick/utilities.py`](diffhunk://#diff-c44e1c527dac8e42ebee84228c123fd84d313d4e9a85d6bd7e8c6cf7b619a9d4R1-R17): Added the `string_to_info_block_data` function to convert a string to a byte array of 32 bytes, filling the rest of the bytes with zeros.

Testing:

* [`tests/utilities/test_string_to_info_block.py`](diffhunk://#diff-e95a2fdb36269241ea2bf94e8d3f7b61bb9aba7f50372914f590f946a51d2169R1-R29): Added tests for the `string_to_info_block_data` function to ensure it correctly converts strings to byte arrays, handles empty strings, truncates long strings, and processes strings with exactly 31 characters.