### PR TITLE
Rationalise accessing of read-only device attributes by use of a BlinkStickDevice class

### DIFF
--- a/src/blinkstick/backends/base.py
+++ b/src/blinkstick/backends/base.py
@@ -20,7 +20,7 @@ class BaseBackend(ABC, Generic[T]):
 
     @staticmethod
     @abstractmethod
-    def get_attached_blinkstick_devices(find_all: bool = True) -> list[T] | None:
+    def get_attached_blinkstick_devices(find_all: bool = True) -> list[T]:
         raise NotImplementedError
 
     @staticmethod

--- a/src/blinkstick/backends/base.py
+++ b/src/blinkstick/backends/base.py
@@ -15,12 +15,12 @@ class BaseBackend(ABC, Generic[T]):
         self.serial = None
 
     @abstractmethod
-    def _refresh_device(self):
+    def _refresh_attached_blinkstick_device(self):
         raise NotImplementedError
 
     @staticmethod
     @abstractmethod
-    def find_blinksticks(find_all: bool = True) -> list[T] | None:
+    def get_attached_blinkstick_devices(find_all: bool = True) -> list[T] | None:
         raise NotImplementedError
 
     @staticmethod

--- a/src/blinkstick/backends/base.py
+++ b/src/blinkstick/backends/base.py
@@ -4,12 +4,15 @@ from abc import ABC, abstractmethod
 
 from typing import TypeVar, Generic
 
+from blinkstick.devices.device import BlinkStickDevice
+
 T = TypeVar("T")
 
 
 class BaseBackend(ABC, Generic[T]):
 
     serial: str | None
+    blinkstick_device: BlinkStickDevice[T]
 
     def __init__(self):
         self.serial = None
@@ -20,12 +23,14 @@ class BaseBackend(ABC, Generic[T]):
 
     @staticmethod
     @abstractmethod
-    def get_attached_blinkstick_devices(find_all: bool = True) -> list[T]:
+    def get_attached_blinkstick_devices(
+        find_all: bool = True,
+    ) -> list[BlinkStickDevice[T]]:
         raise NotImplementedError
 
     @staticmethod
     @abstractmethod
-    def find_by_serial(serial: str) -> list[T] | None:
+    def find_by_serial(serial: str) -> list[BlinkStickDevice[T]] | None:
         raise NotImplementedError
 
     @abstractmethod
@@ -39,18 +44,14 @@ class BaseBackend(ABC, Generic[T]):
     ):
         raise NotImplementedError
 
-    @abstractmethod
     def get_serial(self) -> str:
-        raise NotImplementedError
+        return self.blinkstick_device.serial
 
-    @abstractmethod
     def get_manufacturer(self) -> str:
-        raise NotImplementedError
+        return self.blinkstick_device.manufacturer
 
-    @abstractmethod
     def get_version_attribute(self) -> int:
-        raise NotImplementedError
+        return self.blinkstick_device.version_attribute
 
-    @abstractmethod
-    def get_description(self) -> str:
-        raise NotImplementedError
+    def get_description(self):
+        return self.blinkstick_device.description

--- a/src/blinkstick/backends/unix_like.py
+++ b/src/blinkstick/backends/unix_like.py
@@ -49,10 +49,6 @@ class UnixLikeBackend(BaseBackend[usb.core.Device]):
         )
         return [
             # TODO: refactor this to DRY up the usb.util.get_string calls
-            # note that we can't use _usb_get_string here because we're not in an instance method
-            # and we don't have a BlinkStickDevice instance to call it on
-            # until then we'll just have to live with the duplication, and the fact that we're not able
-            # to handle USB errors in the same way as we do in the instance methods
             BlinkStickDevice(
                 raw_device=device,
                 serial=str(usb.util.get_string(device, 3, 1033)),
@@ -91,26 +87,6 @@ class UnixLikeBackend(BaseBackend[usb.core.Device]):
             if self._refresh_attached_blinkstick_device():
                 return self.blinkstick_device.raw_device.ctrl_transfer(
                     bmRequestType, bRequest, wValue, wIndex, data_or_wLength
-                )
-            else:
-                raise BlinkStickException(
-                    "Could not communicate with BlinkStick {0} - it may have been removed".format(
-                        self.serial
-                    )
-                )
-
-    def _usb_get_string(self, index: int) -> str:
-        try:
-            return str(
-                usb.util.get_string(self.blinkstick_device.raw_device, index, 1033)
-            )
-        except usb.USBError:
-            # Could not communicate with BlinkStick backend
-            # attempt to find it again based on serial
-
-            if self._refresh_attached_blinkstick_device():
-                return str(
-                    usb.util.get_string(self.blinkstick_device.raw_device, index, 1033)
                 )
             else:
                 raise BlinkStickException(

--- a/src/blinkstick/backends/unix_like.py
+++ b/src/blinkstick/backends/unix_like.py
@@ -41,14 +41,15 @@ class UnixLikeBackend(BaseBackend[usb.core.Device]):
     @staticmethod
     def get_attached_blinkstick_devices(
         find_all: bool = True,
-    ) -> list[usb.core.Device] | None:
-        return usb.core.find(
-            find_all=find_all, idVendor=VENDOR_ID, idProduct=PRODUCT_ID
+    ) -> list[usb.core.Device]:
+        return (
+            usb.core.find(find_all=find_all, idVendor=VENDOR_ID, idProduct=PRODUCT_ID)
+            or []
         )
 
     @staticmethod
     def find_by_serial(serial: str) -> list[usb.core.Device] | None:
-        found_devices = UnixLikeBackend.get_attached_blinkstick_devices() or []
+        found_devices = UnixLikeBackend.get_attached_blinkstick_devices()
         for d in found_devices:
             try:
                 if usb.util.get_string(d, 3, 1033) == serial:

--- a/src/blinkstick/backends/unix_like.py
+++ b/src/blinkstick/backends/unix_like.py
@@ -5,58 +5,70 @@ import usb.util  # type: ignore
 
 from blinkstick.constants import VENDOR_ID, PRODUCT_ID
 from blinkstick.backends.base import BaseBackend
+from blinkstick.devices.device import BlinkStickDevice
 from blinkstick.exceptions import BlinkStickException
 
 
 class UnixLikeBackend(BaseBackend[usb.core.Device]):
 
     serial: str
-    device: usb.core.Device
+    blinkstick_device: BlinkStickDevice[usb.core.Device]
 
     def __init__(self, device=None):
-        self.device = device
+        self.blinkstick_device = device
         super().__init__()
         if device:
             self.open_device()
             self.serial = self.get_serial()
 
     def open_device(self) -> None:
-        if self.device is None:
+        if self.blinkstick_device is None:
             raise BlinkStickException("Could not find BlinkStick...")
 
-        if self.device.is_kernel_driver_active(0):
+        if self.blinkstick_device.raw_device.is_kernel_driver_active(0):
             try:
-                self.device.detach_kernel_driver(0)
+                self.blinkstick_device.raw_device.detach_kernel_driver(0)
             except usb.core.USBError as e:
                 raise BlinkStickException("Could not detach kernel driver: %s" % str(e))
 
     def _refresh_attached_blinkstick_device(self):
-        if not self.serial:
+        if not self.blinkstick_device:
             return False
-        if devices := self.find_by_serial(self.serial):
-            self.device = devices[0]
+        if devices := self.find_by_serial(self.blinkstick_device.serial):
+            self.blinkstick_device = devices[0]
             self.open_device()
             return True
 
     @staticmethod
     def get_attached_blinkstick_devices(
         find_all: bool = True,
-    ) -> list[usb.core.Device]:
-        return (
+    ) -> list[BlinkStickDevice[usb.core.Device]]:
+        raw_devices = (
             usb.core.find(find_all=find_all, idVendor=VENDOR_ID, idProduct=PRODUCT_ID)
             or []
         )
+        return [
+            # TODO: refactor this to DRY up the usb.util.get_string calls
+            # note that we can't use _usb_get_string here because we're not in an instance method
+            # and we don't have a BlinkStickDevice instance to call it on
+            # until then we'll just have to live with the duplication, and the fact that we're not able
+            # to handle USB errors in the same way as we do in the instance methods
+            BlinkStickDevice(
+                raw_device=device,
+                serial=str(usb.util.get_string(device, 3, 1033)),
+                manufacturer=str(usb.util.get_string(device, 1, 1033)),
+                version_attribute=device.bcdDevice,
+                description=str(usb.util.get_string(device, 2, 1033)),
+            )
+            for device in raw_devices
+        ]
 
     @staticmethod
-    def find_by_serial(serial: str) -> list[usb.core.Device] | None:
+    def find_by_serial(serial: str) -> list[BlinkStickDevice[usb.core.Device]] | None:
         found_devices = UnixLikeBackend.get_attached_blinkstick_devices()
         for d in found_devices:
-            try:
-                if usb.util.get_string(d, 3, 1033) == serial:
-                    devices = [d]
-                    return devices
-            except Exception as e:
-                print("{0}".format(e))
+            if d.serial == serial:
+                return [d]
 
         return None
 
@@ -69,7 +81,7 @@ class UnixLikeBackend(BaseBackend[usb.core.Device]):
         data_or_wLength: bytes | int,
     ):
         try:
-            return self.device.ctrl_transfer(
+            return self.blinkstick_device.raw_device.ctrl_transfer(
                 bmRequestType, bRequest, wValue, wIndex, data_or_wLength
             )
         except usb.USBError:
@@ -77,7 +89,7 @@ class UnixLikeBackend(BaseBackend[usb.core.Device]):
             # attempt to find it again based on serial
 
             if self._refresh_attached_blinkstick_device():
-                return self.device.ctrl_transfer(
+                return self.blinkstick_device.raw_device.ctrl_transfer(
                     bmRequestType, bRequest, wValue, wIndex, data_or_wLength
                 )
             else:
@@ -87,27 +99,19 @@ class UnixLikeBackend(BaseBackend[usb.core.Device]):
                     )
                 )
 
-    def get_serial(self) -> str:
-        return self._usb_get_string(3)
-
-    def get_manufacturer(self) -> str:
-        return self._usb_get_string(1)
-
-    def get_version_attribute(self) -> int:
-        return int(self.device.bcdDevice)
-
-    def get_description(self):
-        return self._usb_get_string(2)
-
     def _usb_get_string(self, index: int) -> str:
         try:
-            return str(usb.util.get_string(self.device, index, 1033))
+            return str(
+                usb.util.get_string(self.blinkstick_device.raw_device, index, 1033)
+            )
         except usb.USBError:
             # Could not communicate with BlinkStick backend
             # attempt to find it again based on serial
 
             if self._refresh_attached_blinkstick_device():
-                return str(usb.util.get_string(self.device, index, 1033))
+                return str(
+                    usb.util.get_string(self.blinkstick_device.raw_device, index, 1033)
+                )
             else:
                 raise BlinkStickException(
                     "Could not communicate with BlinkStick {0} - it may have been removed".format(

--- a/src/blinkstick/backends/win32.py
+++ b/src/blinkstick/backends/win32.py
@@ -25,7 +25,7 @@ class Win32Backend(BaseBackend[hid.HidDevice]):
 
     @staticmethod
     def find_by_serial(serial: str) -> list[hid.HidDevice] | None:
-        found_devices = Win32Backend.find_blinksticks() or []
+        found_devices = Win32Backend.get_attached_blinkstick_devices() or []
         devices = [d for d in found_devices if d.serial_number == serial]
 
         if len(devices) > 0:
@@ -33,7 +33,7 @@ class Win32Backend(BaseBackend[hid.HidDevice]):
 
         return None
 
-    def _refresh_device(self):
+    def _refresh_attached_blinkstick_device(self):
         # TODO This is weird semantics. fix up return values to be more sensible
         if not self.serial:
             return False
@@ -44,7 +44,9 @@ class Win32Backend(BaseBackend[hid.HidDevice]):
             return True
 
     @staticmethod
-    def find_blinksticks(find_all: bool = True) -> list[hid.HidDevice] | None:
+    def get_attached_blinkstick_devices(
+        find_all: bool = True,
+    ) -> list[hid.HidDevice] | None:
         devices = hid.HidDeviceFilter(
             vendor_id=VENDOR_ID, product_id=PRODUCT_ID
         ).get_devices()
@@ -69,7 +71,7 @@ class Win32Backend(BaseBackend[hid.HidDevice]):
                 )
             data[0] = wValue
             if not self.device.send_feature_report(data):
-                if self._refresh_device():
+                if self._refresh_attached_blinkstick_device():
                     self.device.send_feature_report(data)
                 else:
                     raise BlinkStickException(

--- a/src/blinkstick/backends/win32.py
+++ b/src/blinkstick/backends/win32.py
@@ -46,16 +46,14 @@ class Win32Backend(BaseBackend[hid.HidDevice]):
     @staticmethod
     def get_attached_blinkstick_devices(
         find_all: bool = True,
-    ) -> list[hid.HidDevice] | None:
+    ) -> list[hid.HidDevice]:
         devices = hid.HidDeviceFilter(
             vendor_id=VENDOR_ID, product_id=PRODUCT_ID
         ).get_devices()
         if find_all:
             return devices
-        elif len(devices) > 0:
-            return devices[0]
-        else:
-            return None
+
+        return devices[:1]
 
     def control_transfer(
         self, bmRequestType, bRequest, wValue, wIndex, data_or_wLength

--- a/src/blinkstick/backends/win32.py
+++ b/src/blinkstick/backends/win32.py
@@ -7,29 +7,29 @@ from pywinusb import hid  # type: ignore
 
 from blinkstick.constants import VENDOR_ID, PRODUCT_ID
 from blinkstick.backends.base import BaseBackend
+from blinkstick.devices.device import BlinkStickDevice
 from blinkstick.exceptions import BlinkStickException
 
 
 class Win32Backend(BaseBackend[hid.HidDevice]):
     serial: str
-    device: hid.HidDevice
+    blinkstick_device: BlinkStickDevice[hid.HidDevice]
     reports: list[hid.core.HidReport]
 
-    def __init__(self, device=None):
+    def __init__(self, device: BlinkStickDevice[hid.HidDevice]):
         super().__init__()
-        self.device = device
+        self.blinkstick_device = device
         if device:
-            self.device.open()
-            self.reports = self.device.find_feature_reports()
+            self.blinkstick_device.raw_device.open()
+            self.reports = self.blinkstick_device.raw_device.find_feature_reports()
             self.serial = self.get_serial()
 
     @staticmethod
-    def find_by_serial(serial: str) -> list[hid.HidDevice] | None:
-        found_devices = Win32Backend.get_attached_blinkstick_devices() or []
-        devices = [d for d in found_devices if d.serial_number == serial]
-
-        if len(devices) > 0:
-            return devices
+    def find_by_serial(serial: str) -> list[BlinkStickDevice[hid.HidDevice]] | None:
+        found_devices = Win32Backend.get_attached_blinkstick_devices()
+        for d in found_devices:
+            if d.serial == serial:
+                return [d]
 
         return None
 
@@ -38,22 +38,33 @@ class Win32Backend(BaseBackend[hid.HidDevice]):
         if not self.serial:
             return False
         if devices := self.find_by_serial(self.serial):
-            self.device = devices[0]
-            self.device.open()
-            self.reports = self.device.find_feature_reports()
+            self.blinkstick_device = devices[0]
+            self.blinkstick_device.raw_device.open()
+            self.reports = self.blinkstick_device.raw_device.find_feature_reports()
             return True
 
     @staticmethod
     def get_attached_blinkstick_devices(
         find_all: bool = True,
-    ) -> list[hid.HidDevice]:
+    ) -> list[BlinkStickDevice[hid.HidDevice]]:
         devices = hid.HidDeviceFilter(
             vendor_id=VENDOR_ID, product_id=PRODUCT_ID
         ).get_devices()
-        if find_all:
-            return devices
 
-        return devices[:1]
+        blinkstick_devices = [
+            BlinkStickDevice(
+                raw_device=device,
+                serial=device.serial_number,
+                manufacturer=device.vendor_name,
+                version_attribute=device.version_number,
+                description=device.product_name,
+            )
+            for device in devices
+        ]
+        if find_all:
+            return blinkstick_devices
+
+        return blinkstick_devices[:1]
 
     def control_transfer(
         self, bmRequestType, bRequest, wValue, wIndex, data_or_wLength
@@ -68,9 +79,9 @@ class Win32Backend(BaseBackend[hid.HidDevice]):
                     *[c_ubyte(c) for c in data_or_wLength]
                 )
             data[0] = wValue
-            if not self.device.send_feature_report(data):
+            if not self.blinkstick_device.raw_device.send_feature_report(data):
                 if self._refresh_attached_blinkstick_device():
-                    self.device.send_feature_report(data)
+                    self.blinkstick_device.raw_device.send_feature_report(data)
                 else:
                     raise BlinkStickException(
                         "Could not communicate with BlinkStick {0} - it may have been removed".format(
@@ -80,15 +91,3 @@ class Win32Backend(BaseBackend[hid.HidDevice]):
 
         elif bmRequestType == 0x80 | 0x20:
             return self.reports[wValue - 1].get()
-
-    def get_serial(self) -> str:
-        return str(self.device.serial_number)
-
-    def get_manufacturer(self) -> str:
-        return str(self.device.vendor_name)
-
-    def get_version_attribute(self) -> int:
-        return int(self.device.version_number)
-
-    def get_description(self) -> str:
-        return str(self.device.product_name)

--- a/src/blinkstick/blinkstick.py
+++ b/src/blinkstick/blinkstick.py
@@ -15,6 +15,7 @@ from blinkstick.colors import (
     ColorFormat,
 )
 from blinkstick.constants import VENDOR_ID, PRODUCT_ID, BlinkStickVariant
+from blinkstick.devices.device import BlinkStickDevice
 from blinkstick.exceptions import BlinkStickException
 from blinkstick.utilities import string_to_info_block_data
 
@@ -51,7 +52,9 @@ class BlinkStick:
     backend: USBBackend
     bs_serial: str
 
-    def __init__(self, device=None, error_reporting: bool = True):
+    def __init__(
+        self, device: BlinkStickDevice | None = None, error_reporting: bool = True
+    ):
         """
         Constructor for the class.
 
@@ -1418,10 +1421,10 @@ def find_first() -> BlinkStick | None:
     @rtype: BlinkStick
     @return: BlinkStick object or None if no devices are found
     """
-    d = USBBackend.get_attached_blinkstick_devices(find_all=False)
+    blinkstick_devices = USBBackend.get_attached_blinkstick_devices(find_all=False)
 
-    if d:
-        return BlinkStick(device=d)
+    if blinkstick_devices:
+        return BlinkStick(device=blinkstick_devices[0])
 
     return None
 

--- a/src/blinkstick/blinkstick.py
+++ b/src/blinkstick/blinkstick.py
@@ -1403,7 +1403,7 @@ def find_all() -> list[BlinkStick]:
     @return: a list of BlinkStick objects or None if no devices found
     """
     result: list[BlinkStick] = []
-    if (found_devices := USBBackend.find_blinksticks()) is None:
+    if (found_devices := USBBackend.get_attached_blinkstick_devices()) is None:
         return result
     for d in found_devices:
         result.extend([BlinkStick(device=d)])
@@ -1418,7 +1418,7 @@ def find_first() -> BlinkStick | None:
     @rtype: BlinkStick
     @return: BlinkStick object or None if no devices are found
     """
-    d = USBBackend.find_blinksticks(find_all=False)
+    d = USBBackend.get_attached_blinkstick_devices(find_all=False)
 
     if d:
         return BlinkStick(device=d)

--- a/src/blinkstick/devices/device.py
+++ b/src/blinkstick/devices/device.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class BlinkStickDevice(Generic[T]):
+    """A BlinkStick device representation"""
+
+    raw_device: T
+    serial: str
+    manufacturer: str
+    version_attribute: int
+    description: str


### PR DESCRIPTION
This pull request introduces significant changes to the BlinkStick backend classes by refactoring how devices are represented and managed. The most important changes include the introduction of a new `BlinkStickDevice` class, renaming and modifying methods to improve clarity and functionality, and updating the backend classes to utilize the new device representation.

### Introduction of `BlinkStickDevice` class:
* [`src/blinkstick/devices/device.py`](diffhunk://#diff-623aa080f0ca2f67ffb793179a5c5b454352c0b9e1064d97d46163e6794c982bR1-R15): Added a new `BlinkStickDevice` class to encapsulate device properties such as `raw_device`, `serial`, `manufacturer`, `version_attribute`, and `description`.

### Refactoring backend classes:
* [`src/blinkstick/backends/base.py`](diffhunk://#diff-9604602ab17f6e3fd7497820eef724de6af35501f85580969f28512a5db689a8R7-R33): Updated the `BaseBackend` class to use the new `BlinkStickDevice` class, renamed methods for clarity, and removed redundant abstract methods. [[1]](diffhunk://#diff-9604602ab17f6e3fd7497820eef724de6af35501f85580969f28512a5db689a8R7-R33) [[2]](diffhunk://#diff-9604602ab17f6e3fd7497820eef724de6af35501f85580969f28512a5db689a8L42-R57)
* [`src/blinkstick/backends/unix_like.py`](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326R8-R71): Modified the `UnixLikeBackend` class to use `BlinkStickDevice` and updated method implementations accordingly. [[1]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326R8-R71) [[2]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L69-R92) [[3]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L87-R110)
* [`src/blinkstick/backends/win32.py`](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67R10-R67): Updated the `Win32Backend` class to utilize `BlinkStickDevice` and refactored methods for better readability and functionality. [[1]](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67R10-R67) [[2]](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67L71-R84) [[3]](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67L83-L94)

### Updates to BlinkStick class:
* [`src/blinkstick/blinkstick.py`](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bR18): Updated the `BlinkStick` class to accept `BlinkStickDevice` in its constructor and modified the `find_all` and `find_first` methods to use the new `get_attached_blinkstick_devices` method. [[1]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bR18) [[2]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL54-R57) [[3]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL1406-R1409) [[4]](diffhunk://#diff-ba9901424eb6267122f272ab918ed8763f6c8855ed8074c4fbde3932c661520bL1421-R1427)

These changes improve the maintainability and clarity of the codebase by introducing a clear device representation and refactoring methods for better readability and functionality.