### PR TITLE
Move entrypoint script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dev = ["black", "isort", "mypy"]
 test = ["coverage", "pytest", "pytest-cov", "pytest-mock"]
 
 [project.scripts]
-blinkstick = "blinkstick.main:main"
+blinkstick = "scripts.main:main"
 
 [project.urls]
 homepage = "https://pypi.python.org/pypi/blinkstick/"

--- a/src/scripts/main.py
+++ b/src/scripts/main.py
@@ -6,7 +6,7 @@ import sys
 import logging
 
 from blinkstick import find_all, find_by_serial, get_blinkstick_package_version
-from .constants import BlinkStickVariant
+from blinkstick.constants import BlinkStickVariant
 
 logging.basicConfig()
 


### PR DESCRIPTION
This pull request primarily involves moving the entrypoint file and updating import paths accordingly. Additionally, it modifies the script entry point in the `pyproject.toml` file. Below are the key changes:

File renaming and import path updates:

* [`src/scripts/main.py`](diffhunk://#diff-81dd1ce32b60dbdb1133c95a56d3185b99839f713c642805204ff6a6a85e8ec6L9-R9): Renamed from `src/blinkstick/main.py` and updated the import path for `BlinkStickVariant` to reflect the new location.

Configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L24-R24): Changed the `blinkstick` script entry point to point to `scripts.main:main` instead of `blinkstick.main:main`.