### PR TITLE
Tidy up use of devices package

### DIFF
--- a/src/blinkstick/backends/base.py
+++ b/src/blinkstick/backends/base.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 from typing import TypeVar, Generic
 
-from blinkstick.devices.device import BlinkStickDevice
+from blinkstick.devices import BlinkStickDevice
 
 T = TypeVar("T")
 

--- a/src/blinkstick/backends/unix_like.py
+++ b/src/blinkstick/backends/unix_like.py
@@ -5,7 +5,7 @@ import usb.util  # type: ignore
 
 from blinkstick.constants import VENDOR_ID, PRODUCT_ID
 from blinkstick.backends.base import BaseBackend
-from blinkstick.devices.device import BlinkStickDevice
+from blinkstick.devices import BlinkStickDevice
 from blinkstick.exceptions import BlinkStickException
 
 

--- a/src/blinkstick/backends/win32.py
+++ b/src/blinkstick/backends/win32.py
@@ -7,7 +7,7 @@ from pywinusb import hid  # type: ignore
 
 from blinkstick.constants import VENDOR_ID, PRODUCT_ID
 from blinkstick.backends.base import BaseBackend
-from blinkstick.devices.device import BlinkStickDevice
+from blinkstick.devices import BlinkStickDevice
 from blinkstick.exceptions import BlinkStickException
 
 

--- a/src/blinkstick/clients/blinkstick.py
+++ b/src/blinkstick/clients/blinkstick.py
@@ -13,7 +13,7 @@ from blinkstick.colors import (
     ColorFormat,
 )
 from blinkstick.constants import BlinkStickVariant
-from blinkstick.devices.device import BlinkStickDevice
+from blinkstick.devices import BlinkStickDevice
 from blinkstick.exceptions import BlinkStickException
 from blinkstick.utilities import string_to_info_block_data
 

--- a/src/blinkstick/clients/blinkstick.py
+++ b/src/blinkstick/clients/blinkstick.py
@@ -14,7 +14,6 @@ from blinkstick.colors import (
 )
 from blinkstick.constants import BlinkStickVariant
 from blinkstick.devices import BlinkStickDevice
-from blinkstick.exceptions import BlinkStickException
 from blinkstick.utilities import string_to_info_block_data
 
 if sys.platform == "win32":

--- a/src/blinkstick/devices/__init__.py
+++ b/src/blinkstick/devices/__init__.py
@@ -1,0 +1,3 @@
+from .device import BlinkStickDevice
+
+__all__ = ["BlinkStickDevice"]


### PR DESCRIPTION
This pull request includes several changes to improve the import structure and organization of the `blinkstick` package. The most important changes involve consolidating the import of the `BlinkStickDevice` class and updating the `__init__.py` file to expose this class properly.

Improvements to import structure:

* [`src/blinkstick/backends/base.py`](diffhunk://#diff-9604602ab17f6e3fd7497820eef724de6af35501f85580969f28512a5db689a8L7-R7): Changed import to use the `blinkstick.devices` module directly for `BlinkStickDevice`.
* [`src/blinkstick/backends/unix_like.py`](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L8-R8): Updated import to use the `blinkstick.devices` module directly for `BlinkStickDevice`.
* [`src/blinkstick/backends/win32.py`](diffhunk://#diff-c745adbfcffd730440a6a7986b880ef4966e75038c24a9793c53db7ddd5c0c67L10-R10): Modified import to use the `blinkstick.devices` module directly for `BlinkStickDevice`.
* [`src/blinkstick/clients/blinkstick.py`](diffhunk://#diff-d65414e4248ce6f9a32ac377f6a2ed809ecb5862e539cc2cc25dc669b50872dbL16-R16): Consolidated imports by removing redundant `BlinkStickException` import and using the `blinkstick.devices` module directly for `BlinkStickDevice`.

Exposing `BlinkStickDevice` class:

* [`src/blinkstick/devices/__init__.py`](diffhunk://#diff-fe65b2e1bcef5fa2f5c5248c8e6ef86d1cdcb7239901532d00a8b093e47e1d0fR1-R3): Added import and `__all__` declaration to expose the `BlinkStickDevice` class.