### PR TITLE
fix: ensure backend check correctly raises exception when not set

### DIFF
--- a/src/blinkstick/clients/blinkstick.py
+++ b/src/blinkstick/clients/blinkstick.py
@@ -71,7 +71,7 @@ class BlinkStick:
         if callable(attr) and not getattr(attr, "no_backend_required", False):
 
             def wrapper(*args, **kwargs):
-                if self.backend is None:
+                if not getattr(self, "backend", None):
                     raise NotConnected("No backend set")
                 return attr(*args, **kwargs)
 

--- a/tests/clients/test_blinkstick.py
+++ b/tests/clients/test_blinkstick.py
@@ -17,10 +17,11 @@ def test_instantiate():
     assert bs is not None
 
 
-def test_all_methods_require_backend(make_blinkstick):
+def test_all_methods_require_backend():
     """Test that all methods require a backend."""
-    bs = make_blinkstick()
-    bs.backend = None  # noqa
+    # Create an instance of BlinkStick. Note that we do not use the mock, or pass a device.
+    # This is deliberate, as we want to test that all methods raise an exception when the backend is not set.
+    bs = BlinkStick()
 
     class_methods = (
         method


### PR DESCRIPTION
This pull request includes changes to the `BlinkStick` client in `src/blinkstick/clients/blinkstick.py` and its corresponding tests in `tests/clients/test_blinkstick.py`. The most important changes include updating the backend check in the `__getattribute__` method and modifying the test for methods requiring a backend.

Backend check update:

* [`src/blinkstick/clients/blinkstick.py`](diffhunk://#diff-d65414e4248ce6f9a32ac377f6a2ed809ecb5862e539cc2cc25dc669b50872dbL74-R74): Changed the backend check in the `__getattribute__` method to use `getattr` for better attribute handling.

Test modifications:

* [`tests/clients/test_blinkstick.py`](diffhunk://#diff-b9947ee04e396add21d7b13b27cc1fd51d076b464eeb5f3089d617cb517373bcL20-R24): Modified the `test_all_methods_require_backend` test to directly instantiate `BlinkStick` without using a mock or passing a device, ensuring that all methods raise an exception when the backend is not set.