### PR TITLE
feat: add major_version attribute to device initialization

### DIFF
--- a/src/blinkstick/devices/device.py
+++ b/src/blinkstick/devices/device.py
@@ -20,6 +20,7 @@ class BlinkStickDevice(Generic[T]):
     variant: BlinkStickVariant = field(init=False)
 
     def __post_init__(self):
+        self.major_version = self.serial_details.major_version
         self.variant = BlinkStickVariant.from_version_attrs(
             major_version=self.serial_details.major_version,
             version_attribute=self.version_attribute,


### PR DESCRIPTION
This pull request includes an important change to the `BlinkStickDevice` class in the `src/blinkstick/devices/device.py` file. The change involves initializing the `major_version` attribute in the `__post_init__` method.

* [`src/blinkstick/devices/device.py`](diffhunk://#diff-623aa080f0ca2f67ffb793179a5c5b454352c0b9e1064d97d46163e6794c982bR23): Added initialization of the `major_version` attribute in the `__post_init__` method to ensure it is set based on the `serial_details` of the device.