### PR TITLE
Add __repr__ and __str__ methods for improved BlinkStick representation

### DIFF
--- a/src/blinkstick/clients/blinkstick.py
+++ b/src/blinkstick/clients/blinkstick.py
@@ -78,6 +78,22 @@ class BlinkStick:
             return wrapper
         return attr
 
+    def __repr__(self):
+        try:
+            serial = self.get_serial()
+            variant = self.get_variant().description
+        except NotConnected:
+            return "<BlinkStick: Not connected>"
+        return f"<BlinkStick: Variant={variant} Serial={serial}>"
+
+    def __str__(self):
+        try:
+            serial = self.get_serial()
+            variant = self.get_variant().description
+        except NotConnected:
+            return "Blinkstick - Not connected"
+        return f"{variant} ({serial})"
+
     def get_serial(self) -> str:
         """
         Returns the serial number of backend.::


### PR DESCRIPTION
This pull request includes modifications to the `src/blinkstick/clients/blinkstick.py` file to enhance the string representation of the `BlinkStick` class. The most important changes involve adding `__repr__` and `__str__` methods to provide more informative and user-friendly descriptions of `BlinkStick` objects.

Enhancements to string representation:

* Added `__repr__` method to return a detailed string representation of the `BlinkStick` object, including its variant and serial number, or indicating that it is not connected.
* Added `__str__` method to return a simplified string representation of the `BlinkStick` object, including its variant and serial number, or indicating that it is not connected.