### PR TITLE
Introduce Mode enum

### DIFF
--- a/src/blinkstick/clients/blinkstick.py
+++ b/src/blinkstick/clients/blinkstick.py
@@ -14,7 +14,7 @@ from blinkstick.colors import (
 )
 from blinkstick.decorators import no_backend_required
 from blinkstick.devices import BlinkStickDevice
-from blinkstick.enums import BlinkStickVariant
+from blinkstick.enums import BlinkStickVariant, Mode
 from blinkstick.exceptions import NotConnected
 from blinkstick.utilities import string_to_info_block_data
 
@@ -373,7 +373,7 @@ class BlinkStick:
 
         return device_bytes[2 : 2 + count * 3]
 
-    def set_mode(self, mode: int) -> None:
+    def set_mode(self, mode: Mode | int) -> None:
         """
         Set backend mode for BlinkStick Pro. Device currently supports the following modes:
 
@@ -388,6 +388,10 @@ class BlinkStick:
         @type  mode: int
         @param mode: Device mode to set
         """
+        # If mode is an enum, get the value
+        # this will allow the user to pass in the enum directly, and also gate the value to the enum values
+        if not isinstance(mode, int):
+            mode = Mode(mode).value
         control_string = bytes(bytearray([4, mode]))
 
         self.backend.control_transfer(0x20, 0x9, 0x0004, 0, control_string)

--- a/src/blinkstick/enums.py
+++ b/src/blinkstick/enums.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, IntEnum
 
 
 class BlinkStickVariant(Enum):
@@ -38,3 +38,9 @@ class BlinkStickVariant(Enum):
             elif version_attribute == 0x203:
                 return BlinkStickVariant.BLINKSTICK_FLEX
         return BlinkStickVariant.UNKNOWN
+
+
+class Mode(IntEnum):
+    RGB = 1
+    RGB_INVERSE = 2
+    ADDRESSABLE = 3

--- a/tests/clients/test_blinkstick.py
+++ b/tests/clients/test_blinkstick.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from blinkstick.colors import ColorFormat
-from blinkstick.enums import BlinkStickVariant
+from blinkstick.enums import BlinkStickVariant, Mode
 from blinkstick.clients.blinkstick import BlinkStick
 from pytest_mock import MockFixture
 
@@ -310,3 +310,26 @@ def test_inverse_does_not_affect_max_rgb_value(make_blinkstick):
     bs.set_max_rgb_value(100)
     bs.set_inverse(True)
     assert bs.get_max_rgb_value() == 100
+
+
+@pytest.mark.parametrize(
+    "mode, is_valid",
+    [
+        (1, True),
+        (2, True),
+        (3, True),
+        (4, False),
+        (-1, False),
+        (Mode.RGB, True),
+        (Mode.RGB_INVERSE, True),
+        (Mode.ADDRESSABLE, True),
+    ],
+)
+def test_set_mode_raises_on_invalid_mode(make_blinkstick, mode, is_valid):
+    """Test that set_mode raises an exception when an invalid mode is passed."""
+    bs = make_blinkstick()
+    if is_valid:
+        bs.set_mode(mode)
+    else:
+        with pytest.raises(ValueError):
+            bs.set_mode("invalid_mode")  # noqa


### PR DESCRIPTION
This pull request includes changes to the `blinkstick` package to improve the handling of device modes by introducing a new `Mode` enum and updating the relevant methods and tests. The most important changes include adding the `Mode` enum, updating the `set_mode` method to accept the new enum, and adding tests to validate the new functionality.

Enhancements to device mode handling:

* [`src/blinkstick/enums.py`](diffhunk://#diff-58412af95e82c6f152ebd7a1d2f545b0d221254cc2a30f17aa88b008ccb89ac1L3-R3): Introduced the `Mode` enum to represent different device modes. [[1]](diffhunk://#diff-58412af95e82c6f152ebd7a1d2f545b0d221254cc2a30f17aa88b008ccb89ac1L3-R3) [[2]](diffhunk://#diff-58412af95e82c6f152ebd7a1d2f545b0d221254cc2a30f17aa88b008ccb89ac1R41-R46)
* [`src/blinkstick/clients/blinkstick.py`](diffhunk://#diff-d65414e4248ce6f9a32ac377f6a2ed809ecb5862e539cc2cc25dc669b50872dbL17-R17): Updated the `set_mode` method to accept either an integer or a `Mode` enum, and added logic to convert the enum to its corresponding integer value. [[1]](diffhunk://#diff-d65414e4248ce6f9a32ac377f6a2ed809ecb5862e539cc2cc25dc669b50872dbL17-R17) [[2]](diffhunk://#diff-d65414e4248ce6f9a32ac377f6a2ed809ecb5862e539cc2cc25dc669b50872dbL376-R376) [[3]](diffhunk://#diff-d65414e4248ce6f9a32ac377f6a2ed809ecb5862e539cc2cc25dc669b50872dbR391-R394)

Testing improvements:

* [`tests/clients/test_blinkstick.py`](diffhunk://#diff-b9947ee04e396add21d7b13b27cc1fd51d076b464eeb5f3089d617cb517373bcL6-R6): Added a parameterized test to ensure that the `set_mode` method raises an exception when an invalid mode is passed, and accepts valid modes including the new `Mode` enum values. [[1]](diffhunk://#diff-b9947ee04e396add21d7b13b27cc1fd51d076b464eeb5f3089d617cb517373bcL6-R6) [[2]](diffhunk://#diff-b9947ee04e396add21d7b13b27cc1fd51d076b464eeb5f3089d617cb517373bcR313-R335)