### PR TITLE
Provide a friendlier exception fhen no usb backend found on unix-like systems

### DIFF
--- a/src/blinkstick/exceptions.py
+++ b/src/blinkstick/exceptions.py
@@ -7,3 +7,7 @@ class BlinkStickException(Exception):
 
 class NotConnected(BlinkStickException):
     pass
+
+
+class USBBackendNotAvailable(BlinkStickException):
+    pass


### PR DESCRIPTION
This pull request includes changes to improve error handling in the `blinkstick` library, specifically within the Unix-like backend. The most important changes include adding a new exception for USB backend availability and updating the device discovery method to handle this new exception. This exception specifically mentions the availability of libusb, to provide improved signposting towards remediation for users.

Error handling improvements:

* [`src/blinkstick/backends/unix_like.py`](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L9-R9): Added import for `USBBackendNotAvailable` exception and updated the `get_attached_blinkstick_devices` method to raise this exception if the USB backend is not available. [[1]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326L9-R9) [[2]](diffhunk://#diff-d25aa91c98775085762354f280a1949656c5452b23f3d3cfb824d7d54d73f326R41-R51)
* [`src/blinkstick/exceptions.py`](diffhunk://#diff-9fb066a0abbf0711523a07ef8f8a432588f468773ee544b15627cc6eed59c2cfR10-R13): Added a new `USBBackendNotAvailable` exception class to handle cases where the USB backend is not available.