### PR TITLE
fix: re-enable add udev rule functionality

### DIFF
--- a/src/scripts/main.py
+++ b/src/scripts/main.py
@@ -304,7 +304,7 @@ def main():
         sticks = [find_by_serial(options.serial)]
 
         if len(sticks) == 0:
-            print("BlinkStick with serial number " + options.backend + " not found...")
+            print("BlinkStick with serial number " + options.serial + " not found...")
             return 64
 
     for stick in sticks:

--- a/src/scripts/main.py
+++ b/src/scripts/main.py
@@ -269,21 +269,12 @@ def main():
         "--add-udev-rule",
         action="store_true",
         dest="udev",
-        help="Add udev rule to access BlinkSticks without root permissions. Must be run as root.",
+        help="Add udev rule to access BlinkSticks without root permissions. Must be run as root e.g. `sudo $(which blinkstick) --add-udev-rule`.",
     )
 
     parser.add_option_group(group)
 
     (options, args) = parser.parse_args()
-
-    if options.serial is None:
-        sticks = find_all()
-    else:
-        sticks = [find_by_serial(options.serial)]
-
-        if len(sticks) == 0:
-            print("BlinkStick with serial number " + options.backend + " not found...")
-            return 64
 
     # Global action
     if options.udev:
@@ -306,6 +297,15 @@ def main():
 
         print("Reboot your computer for changes to take effect")
         return 0
+
+    if options.serial is None:
+        sticks = find_all()
+    else:
+        sticks = [find_by_serial(options.serial)]
+
+        if len(sticks) == 0:
+            print("BlinkStick with serial number " + options.backend + " not found...")
+            return 64
 
     for stick in sticks:
         if options.inverse:


### PR DESCRIPTION
This pull request includes changes to the `src/scripts/main.py` file to re-enable the --add-udev-rule functionality in the blinkstick cli tool, and improve the clarity of help messages. The most important changes include updating the help text for the `--add-udev-rule` option and reordering the logic for finding BlinkStick devices based on serial numbers.

Improvements to help messages:

* Updated the help text for the `--add-udev-rule` option to include an example command for running it with root permissions.

Code reorganization:

* Moved the logic for adding the udev rule to a more appropriate location in the `main` function, ensuring it is executed before any actions which require finding BlinkStick devices